### PR TITLE
feat: Added `show_diff` for pretty printing the difference between two strings during a failed equality test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /docs/Manifest.toml
 /docs/build/
 *.code-workspace
+LocalPreferences.toml

--- a/Project.toml
+++ b/Project.toml
@@ -6,9 +6,11 @@ version = "1.1.1"
 [deps]
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 MLStyle = "0.4"
 OrderedCollections = "1.6"
+Preferences = "1"
 julia = "1.6"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,9 +19,11 @@ makedocs(;
         canonical="https://curtd.github.io/TestingUtilities.jl",
         edit_link="main",
         assets=String[],
+        ansicolor=true
     ),
     pages=[
         "Home" => "index.md",
+        "Settings" => "settings.md",
         "API" => "api.md"
     ],
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,3 +5,7 @@ Modules = [TestingUtilities]
 Order   = [:macro, :function] 
 Private = false
 ```
+
+```@docs 
+TestingUtilities.set_show_diff_styles(; matching, differing)
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,4 +4,4 @@ CurrentModule = TestingUtilities
 
 # TestingUtilities
 
-The [TestingUtilities](https://github.com/curtd/TestingUtilities.jl) provides macros that make testing your code less tedious and more insightful. 
+The [TestingUtilities](https://github.com/curtd/TestingUtilities.jl) provides macros that make testing your code less tedious and (hopefully) more insightful. 

--- a/docs/src/settings.md
+++ b/docs/src/settings.md
@@ -1,0 +1,41 @@
+# Settings 
+`TestingUtilities` makes use of the `Preferences` package to store package-side settings for various test failure scenarios.
+
+## String Comparison Tests 
+When performing an equality comparison test between two `String` values, say `x` and `y`, if the test fails and the provided `io` object supports printing colours, the matching shared prefix of `x` and `y` will be rendered in green while the differing components of `x` and `y` will be rendered in red.
+
+```@setup settings
+using TestingUtilities, Test
+
+mutable struct NoThrowTestSet <: Test.AbstractTestSet
+    results::Vector
+    NoThrowTestSet(desc) = new([])
+end
+Test.record(ts::NoThrowTestSet, t::Test.Result) = (push!(ts.results, t); t)
+Test.finish(ts::NoThrowTestSet) = ts.results
+test_results_match = (results, ref_results)-> all(result isa ref_result for (result, ref_result) in zip(results, ref_results) )
+
+TestingUtilities.set_show_diff_styles(; matching=:color => :green, differing=:color => :red)
+```
+
+```@example settings
+a = "abcd" 
+b = "abef"
+c = "abeghik"
+@testset NoThrowTestSet "" begin 
+    @Test a == b
+    @Test isequal(c, "abeg")
+end
+nothing # hide
+```
+
+If you're unable to distinguish between the default colours (or colours more generally), you can set the styles used to render the matching components and differing components of the strings by invoking [`TestingUtilities.set_show_diff_styles`](@ref). You can use any `key => value` pair corresponding to the keyword arguments of [`Base.printstyled`](https://docs.julialang.org/en/v1/base/io-network/#Base.printstyled).
+
+```@example settings 
+TestingUtilities.set_show_diff_styles(; matching=:bold => true, differing=:underline => true)
+@testset NoThrowTestSet "" begin 
+    @Test a == b
+    @Test isequal(c, "abeg")
+end
+nothing # hide
+```

--- a/src/TestingUtilities.jl
+++ b/src/TestingUtilities.jl
@@ -1,6 +1,6 @@
 module TestingUtilities
 
-    using MLStyle, OrderedCollections, Test
+    using MLStyle, OrderedCollections, Preferences, Test
     
     export @Test, @test_cases   
 
@@ -10,11 +10,15 @@ module TestingUtilities
     
     include("settings.jl")
 
+    include("show_values.jl")
+    
     include("macro_util.jl")
 
     include("computational_graph.jl")
 
-    include("show_values_macro.jl")
+    include("macros/_macros.jl")
 
-    include("test_cases.jl")
+    function __init__()
+        load_show_diff_styles()
+    end
 end

--- a/src/macros/_macros.jl
+++ b/src/macros/_macros.jl
@@ -1,0 +1,2 @@
+include("Test.jl")
+include("test_cases.jl")

--- a/src/macros/test_cases.jl
+++ b/src/macros/test_cases.jl
@@ -217,9 +217,12 @@ macro test_cases(args...)
                 println(io, "Test `" * $(string(evaluate_test_expr)) *"` failed with values:")
                 for (num,t) in enumerate(failed_test_data[$i])
                     println(io, "------")
+                    already_shown = Set(Any[$(QuoteNode(_DEFAULT_TEST_EXPR_KEY))])
+                    $(generate_show_diff_expr(:already_shown, :t))
                     for (k,v) in pairs(t)
-                        if !(k === $(QuoteNode(_DEFAULT_TEST_EXPR_KEY)))
+                        if k ∉ already_shown
                             TestingUtilities.show_value(k,v; io)
+                            push!(already_shown, k)
                         end
                     end
                 end

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -16,8 +16,7 @@ end
 """
     define_vars_in_failed_tests(value::Bool)
 
-If `value` is `true`, variables that cause a `@Test` expression to fail will be 
-defined in `Main` when Julia is run in interactive mode.
+If `value` is `true`, variables that cause a `@Test` expression to fail will be defined in `Main` when Julia is run in interactive mode.
 
 Defaults to `true` if unset. 
 """
@@ -38,4 +37,74 @@ Defaults to `false` if unset.
 function emit_warnings(value::Bool) 
     _TESTING_SETTINGS[EmitWarnings] = value
     return nothing 
+end
+
+const printstyled_bool_kwargs = (:bold, :underline, :blink, :reverse, :hidden)
+
+const show_diff_matching_style = Pair{Symbol, Any}[:color => :green]
+
+const show_diff_differing_style = Pair{Symbol, Any}[:color => :red]
+
+pref_to_string(p::Pair) = string(first(p)) * "=" * string(last(p))
+
+pref_to_string(p::Vector{<:Pair}) = join([pref_to_string(pi) for pi in p], ",")
+
+function parse_load_styles(str::AbstractString)
+    kwargs = Pair{Symbol,Any}[]
+    str_split = split(str, ",")
+    for s in str_split
+        isempty(s) && continue
+        s_split = split(s, "=")
+        length(s_split) == 2 || error("Cannot parse pair from string $s")
+        key = Symbol(s_split[1])
+        if key in printstyled_bool_kwargs
+            value = tryparse(Bool, s_split[2])
+            isnothing(value) && error("Cannot parse Bool for key $key from input $(s_split[1])")
+            push!(kwargs, key => value)
+        else
+            push!(kwargs, key => Symbol(s_split[2]))
+        end
+    end
+    return kwargs
+end
+
+function load_show_diff_styles(; 
+    matching_style::String = "", 
+    differing_style::String = "")
+    if isempty(matching_style)
+        matching_style = @load_preference("show_diff_matching_style", "")
+    end
+    matching_style_opts = parse_load_styles(matching_style)
+    if !isempty(matching_style_opts)
+        copy!(show_diff_matching_style, matching_style_opts)
+    end
+    if isempty(differing_style)
+        differing_style = @load_preference("show_diff_differing_style", "")
+    end
+    differing_style_opts = parse_load_styles(differing_style)
+    if !isempty(differing_style_opts)
+        copy!(show_diff_differing_style, differing_style_opts)
+    end
+    return nothing
+end
+
+"""
+    set_show_diff_styles(; matching=show_diff_matching_style, differing=show_diff_differing_style)
+
+Sets the local style information for the `show_diff` method, which is invoked when displaying two differing `String` values. 
+
+Both `matching` and `differing` must each be a `Pair` whose keys and values correspond to the keyword arguments of the [`Base.printstyled`](https://docs.julialang.org/en/v1/base/io-network/#Base.printstyled) function, or a `Vector` of such `Pair`s.
+"""
+function set_show_diff_styles(; matching::Union{Pair, Vector{<:Pair}}=show_diff_matching_style, differing::Union{Pair, Vector{<:Pair}}=show_diff_differing_style)
+    if matching isa Pair 
+        matching = [matching]
+    end
+    if differing isa Pair 
+        differing = [differing]
+    end
+    @set_preferences!("show_diff_matching_style" => pref_to_string(matching))
+    @set_preferences!("show_diff_differing_style" => pref_to_string(differing))
+
+    load_show_diff_styles()
+    return nothing
 end

--- a/src/show_values.jl
+++ b/src/show_values.jl
@@ -1,0 +1,64 @@
+function show_value(value; io=stderr, compact::Bool=true)
+    ctx = IOContext(io, :compact => compact)
+    println(ctx, repr(value))
+    flush(ctx)
+end
+
+function show_value(name, value; io=stderr, compact::Bool=true)
+    ctx = IOContext(io, :compact => compact)
+    if name isa Expr
+        print(ctx, "`")
+        Base.show_unquoted(ctx, name)
+        print(ctx, "`")
+    else
+        Base.show_unquoted(ctx, name)
+    end
+    print(ctx, " = ")
+    println(ctx, repr(value))
+    flush(ctx)
+end
+
+function show_escape_newlines(io, str::AbstractString; has_colour::Bool=false, is_matching::Bool)
+    replaced_str = replace(str, "\n" => "\\n")
+    if has_colour 
+        if is_matching
+            style = NamedTuple(show_diff_matching_style)
+        else
+            style = NamedTuple(show_diff_differing_style)
+        end
+        printstyled(io, replaced_str; style...)
+    else
+        print(io, replaced_str)
+    end
+end
+
+function show_diff(expected::AbstractString, result::AbstractString; expected_name="expected", result_name="result", io=stderr, compact::Bool=true)
+    ctx = IOContext(io, :compact => compact)
+    has_colour = get(io, :color, false)
+    if startswith(expected, result)
+        common_prefix_length = length(result)
+        common_prefix = result
+    elseif startswith(result, expected)
+        common_prefix_length = length(expected)
+        common_prefix = expected
+    else
+        common_prefix_length = something(findfirst(i->expected[i] != result[i], 1:min(length(expected), length(result))), 1)-1
+        common_prefix = expected[1:common_prefix_length]
+    end
+    expected_name_str = string(expected_name)
+    expected_width = textwidth(expected_name_str)
+    result_name_str = string(result_name)
+    result_width = textwidth(result_name_str)
+    longest_width = max(expected_width, result_width)
+    for (text, text_name, width) in ((expected, expected_name_str, expected_width), (result, result_name_str, result_width))
+        print(ctx, text_name, repeat(' ', longest_width-width), " = ")
+        print(ctx, '\"')
+        show_escape_newlines(ctx, common_prefix; has_colour, is_matching=true)
+        show_escape_newlines(ctx, text[common_prefix_length+1:end]; has_colour, is_matching=false)
+        println(ctx, '\"')
+    end
+    flush(ctx)
+    return true
+end
+
+show_diff(expected, result; kwargs...) = false

--- a/src/util.jl
+++ b/src/util.jl
@@ -10,3 +10,12 @@ end
 const imported_names_in_main = Ref(Set{Symbol}())
 
 update_imported_names_in_main() = imported_names_in_main[] = module_using_names(Main) 
+
+function unescape(x)
+    @switch x begin 
+        @case Expr(:$, arg) || Expr(:escape, arg)
+            return unescape(arg)
+        @case _ 
+            return x
+    end
+end

--- a/test/TestTestingUtilities.jl
+++ b/test/TestTestingUtilities.jl
@@ -16,7 +16,7 @@ module TestTestingUtilities
 
     include("test_settings.jl")
 
-    include("test_show_values_macro.jl")
+    include("test_Test_macro.jl")
     
     include("test_cases_macro.jl")
 

--- a/test/test_cases_macro.jl
+++ b/test/test_cases_macro.jl
@@ -1,5 +1,4 @@
-remove_quoting(expr::Expr) = Meta.isexpr(expr, :$) ? remove_quoting(expr.args[1]) : expr
-remove_quoting(expr) = expr
+append_char(x, c; n::Int) = x * repeat(c, n)
 
 @testset "@test_cases" begin 
     @testset "Util" begin 
@@ -124,4 +123,16 @@ remove_quoting(expr) = expr
     @test test_results_match(results, (Test.Error,))
     @test results[1].value == "ErrorException(\"asdf\")"
     
+    results = Test.@testset NoThrowTestSet "String comparison" begin 
+        io = IOBuffer()
+        @test_cases io=io begin 
+            a     | b   | output 
+            "abc" | 'd' | "abcd"
+            "abc" | 'e' | "abce"
+            @test append_char(a, b; n=3) == output
+        end
+        message = String(take!(io))
+        @test message ==  "Test `append_char(a, b; n = 3) == output` failed with values:\n------\nappend_char(a, b; n = 3) = \"abcddd\"\noutput                   = \"abcd\"\na = \"abc\"\nb = 'd'\n------\nappend_char(a, b; n = 3) = \"abceee\"\noutput                   = \"abce\"\na = \"abc\"\nb = 'e'\n"
+    end
+    @test test_results_match(results, (Test.Fail, Test.Fail, Test.Pass))
 end

--- a/test/test_settings.jl
+++ b/test/test_settings.jl
@@ -18,4 +18,20 @@
         TestingUtilities.emit_warnings(b) 
         @test TestingUtilities.testing_setting(TestingUtilities.EmitWarnings) == b 
     end
+
+    TestingUtilities.set_show_diff_styles(; matching=:color => :green, differing=:color => :red)
+    @test TestingUtilities.show_diff_matching_style == [:color => :green]
+    @test TestingUtilities.show_diff_differing_style == [:color => :red]
+    TestingUtilities.set_show_diff_styles(; matching=:bold => true, differing=:underline => true)
+    @test TestingUtilities.show_diff_matching_style == [:bold => true]
+    @test TestingUtilities.show_diff_differing_style == [:underline => true]
+    
+    @test_throws ErrorException TestingUtilities.set_show_diff_styles(; matching=:bold => :bad_val, differing=:underline => :bad_val)
+    @test TestingUtilities.show_diff_matching_style == [:bold => true]
+    @test TestingUtilities.show_diff_differing_style == [:underline => true,]
+
+    TestingUtilities.set_show_diff_styles(; matching=[:color => :green, :underline => true], differing=[:color => :red, :underline => true])
+    @test TestingUtilities.show_diff_matching_style == [:color => :green, :underline => true]
+    @test TestingUtilities.show_diff_differing_style == [:color => :red, :underline => true]
+
 end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -82,8 +82,10 @@ end
             TestingUtilities.show_diff(expected, result; io)
             @test String(take!(buf)) == output
         end
-        TestingUtilities.set_show_diff_styles(; matching=:bold => true, differing=:underline => true)
-        TestingUtilities.show_diff("abcd", "abef"; io)
-        @test String(take!(buf)) == "expected = \"\e[0m\e[1mab\e[22m\e[0m\e[4mcd\e[24m\"\nresult   = \"\e[0m\e[1mab\e[22m\e[0m\e[4mef\e[24m\"\n"
+        if VERSION ≥ v"1.7"
+            TestingUtilities.set_show_diff_styles(; matching=:bold => true, differing=:underline => true)
+            TestingUtilities.show_diff("abcd", "abef"; io)
+            @test String(take!(buf)) == "expected = \"\e[0m\e[1mab\e[22m\e[0m\e[4mcd\e[24m\"\nresult   = \"\e[0m\e[1mab\e[22m\e[0m\e[4mef\e[24m\"\n"
+        end
     end
 end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -58,7 +58,10 @@ end
             (; expected = "ab\nc", result = "ab", output = "expected = \"ab\\nc\"\nresult   = \"ab\"\n"),
             (; expected = "ab\nc", result = "ab\n", output = "expected = \"ab\\nc\"\nresult   = \"ab\\n\"\n"),
         ]
-        for (; expected, result, output) in test_data 
+        for data in test_data 
+            expected = data.expected 
+            result = data.result
+            output = data.output
             TestingUtilities.show_diff(expected, result; io)
             @test String(take!(io)) == output
         end
@@ -72,7 +75,10 @@ end
             (; expected = "ab\nc", result = "ab", output = "expected = \"\e[32mab\e[39m\e[31m\\nc\e[39m\"\nresult   = \"\e[32mab\e[39m\"\n"),
             (; expected = "ab\nc", result = "ab\n", output = "expected = \"\e[32mab\\n\e[39m\e[31mc\e[39m\"\nresult   = \"\e[32mab\\n\e[39m\"\n"),
         ]
-        for (; expected, result, output) in test_data 
+        for data in test_data 
+            expected = data.expected 
+            result = data.result
+            output = data.output
             TestingUtilities.show_diff(expected, result; io)
             @test String(take!(buf)) == output
         end


### PR DESCRIPTION
fix: Fixed short-circuiting test expressions