### PR TITLE
feat: Added `set_max_print_length` setting function for limiting the maximum number of characters displayed for outputting generic values

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,6 +26,7 @@ makedocs(;
         "Settings" => "settings.md",
         "API" => "api.md"
     ],
+    warnonly=[:missing_docs]
 )
 
 deploydocs(;

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -9,6 +9,7 @@ Private = false
 ## Settings 
 ```@docs 
 TestingUtilities.set_show_diff_styles(; matching, differing)
-TestingUtilities.set_show_df_opts(; max_num_rows, max_num_cols)
-TestingUtilities.set_show_diff_df_opts(; max_num_rows, max_num_cols)
+TestingUtilities.set_show_df_opts(; max_num_rows, max_num_cols, save_preference)
+TestingUtilities.set_show_diff_df_opts(; max_num_rows, max_num_cols, save_preference)
+TestingUtilities.set_max_print_length(; max_print_length, save_preference)
 ```

--- a/src/show_diff/common.jl
+++ b/src/show_diff/common.jl
@@ -55,7 +55,7 @@ Base.eachindex(p::PrintAligned) = eachindex(p.header_strs)
 should_ignore_struct_type((@nospecialize x)) = false 
 should_print_differing_fields_header((@nospecialize x)) = true
 
-for T in (String, AbstractDict, AbstractVector, AbstractSet)
+for T in (String, AbstractDict, AbstractVector, AbstractSet, Dates.TimeType, Dates.AbstractDateTime, Dates.Period)
     @eval should_ignore_struct_type(::Type{<:$T}) = true
     @eval should_print_differing_fields_header(::Type{<:$T}) = false
 end

--- a/src/show_values.jl
+++ b/src/show_values.jl
@@ -26,8 +26,13 @@ function show_value(ctx::IOContext, value::Ref; kwargs...)
     return result
 end
 
-function show_value(ctx::IOContext, value; kwargs...)
-    println(ctx, repr(value))
+function show_value(ctx::IOContext, value; max_print_length::Int=max_length_to_print[], kwargs...)
+    s = repr(value; context = :limit => false)
+    no_whitespace_length = findprev(!isspace, s, length(s))
+    if !isnothing(no_whitespace_length) && (no_whitespace_length > max_print_length)
+        s = s[1:max_print_length]*"..."*s[no_whitespace_length+1:end]
+    end
+    println(ctx, s)
     flush(ctx)
     return nothing
 end

--- a/test/test_settings.jl
+++ b/test/test_settings.jl
@@ -34,4 +34,21 @@
     @test TestingUtilities.show_diff_matching_style == [:color => :green, :underline => true]
     @test TestingUtilities.show_diff_differing_style == [:color => :red, :underline => true]
 
+    io = IOBuffer()
+    value = collect(1:10)
+    message_prefix = "a = "
+    original_message = "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n"
+    no_whitespace_length = length(original_message)-1
+    try 
+        for max_print_length in 1:no_whitespace_length+1
+            TestingUtilities.set_max_print_length(; max_print_length, save_preference=false)
+            TestingUtilities.show_value(:a, value; io)
+            message = String(take!(io))
+            ref_message = message_prefix *( max_print_length ≥ no_whitespace_length ? original_message : original_message[1:max_print_length]*"...\n")
+            @test message == ref_message
+        end
+        
+    finally 
+        TestingUtilities.set_max_print_length()
+    end
 end

--- a/test/test_util/test_show_diff.jl
+++ b/test/test_util/test_show_diff.jl
@@ -207,6 +207,18 @@
         """
         @test message == ref_message
 
+        # Don't recurse into Date/Time/Period types
+        for (expected, result) in [(Date(2023, 1, 1), Date(2023, 1, 2)), (DateTime(2023, 1, 1), DateTime(2023, 1, 2)), (Time(9, 30), Time(9, 31)), (Second(1), Second(2))]
+            io = IOBuffer()
+            TestingUtilities.show_diff(expected, result; io=io)
+            message = String(take!(io))
+            T = typeof(expected)
+            ref_message = """
+            expected::$(T) = $(repr(expected))
+              result::$(T) = $(repr(result))
+            """
+            @test message == ref_message
+        end
     end
     @testset "Generic values" begin 
         expected_1_1 = ShowDiffChild1_1("abc", 1)


### PR DESCRIPTION
fix: Don't recursively print fields for types from `Dates` module